### PR TITLE
Don't clear connectTimeout until ConnectResponse is received

### DIFF
--- a/lib/ConnectionManager.js
+++ b/lib/ConnectionManager.js
@@ -303,10 +303,6 @@ ConnectionManager.prototype.onSocketConnected = function () {
         header,
         payload;
 
-    if (this.connectTimeoutHandler) {
-        clearTimeout(this.connectTimeoutHandler);
-    }
-
     connectRequest = new jute.Request(null, new jute.protocol.ConnectRequest(
         jute.PROTOCOL_VERSION,
         this.zxid,
@@ -428,6 +424,9 @@ ConnectionManager.prototype.onSocketData = function (buffer) {
         connectResponse = new jute.protocol.ConnectResponse();
         offset += connectResponse.deserialize(buffer, offset);
 
+        if (this.connectTimeoutHandler) {
+            clearTimeout(this.connectTimeoutHandler);
+        }
 
         if (connectResponse.timeOut <= 0) {
             self.setState(STATES.SESSION_EXPIRED);


### PR DESCRIPTION
Otherwise we leave a window between when the TCP connection emits
'connect' and we've sent the ConnectRequest, and when the
ConnectResponse comes back, when we have no timeout applying at
all and no attempt to talk to the socket again.

If we get netsplit from ZK during such a window, we may hang in
the CONNECTING state indefinitely.